### PR TITLE
Add links to Commerce.js and Gridsome in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![npm](https://img.shields.io/npm/v/gridsome-source-commercejs)
 
-Commerce.js source plugin for Gridsome
+[Commerce.js](http://commercejs.com/) source plugin for [Gridsome](https://gridsome.org/).
 
 ## Install
 


### PR DESCRIPTION
Nice work creating the plugin! I'm just proposing some extra links in the readme here for context.